### PR TITLE
Fix string quoting bug in math agent script

### DIFF
--- a/scripts/agents/math_agent.py
+++ b/scripts/agents/math_agent.py
@@ -32,7 +32,7 @@ def main():
 
     response = agent.invoke(input('Write your math question\n--> '), handle_parsing_errors=True)
 
-    print(f'ChatGPT:\n{response['output']}')
+    print(f"ChatGPT:\n{response['output']}")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- fix incorrect string quoting in `math_agent` to ensure valid f-string evaluation

## Testing
- `python -m py_compile scripts/agents/math_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_689592ff4a4c8329bfeb6216a584ecd3